### PR TITLE
Checking if a volume is renameable before renaming it.

### DIFF
--- a/CommandFileIO.cs
+++ b/CommandFileIO.cs
@@ -157,7 +157,9 @@ namespace kOS
                 int intTry;
                 if (int.TryParse(newName.Substring(0, 1), out intTry)) throw new kOSException("Volume name cannot start with numeral");
 
-                targetVolume.Name = newName;
+                if (targetVolume.Renameable) targetVolume.Name = newName;
+                else throw new kOSException("Volume cannot be renamed");
+
                 State = ExecutionState.DONE;
                 return;
             }


### PR DESCRIPTION
Noticed the renameable boolean wasn't being used anywhere, so added it.
