### PR TITLE
Added LOG command.  Logs to a file on the archive volume but only if the volume is within range.

### DIFF
--- a/CommandFileIO.cs
+++ b/CommandFileIO.cs
@@ -184,6 +184,39 @@ namespace kOS
             throw new kOSException("Unrecognized renamable object type '" + operation + "'");
         }
     }
+
+    [CommandAttribute(@"^LOG (.+?) (.+?)$")]
+    public class CommandLog: Command
+    {
+        public CommandLog(Match regexMatch, ExecutionContext context) : base(regexMatch, context) { }
+
+        public override void Evaluate()
+        {
+            // For now only log to the archive.
+            String volumeName = "Archive";
+            Volume targetVolume = GetVolume(volumeName);
+
+            // If the archive is out of ranch, the signal is lost in space.
+            if (!targetVolume.CheckRange())
+            {
+                State = ExecutionState.DONE;
+                return;
+            }
+
+            String targetFile = RegexMatch.Groups[1].Value.Trim();
+            Expression e = new Expression(RegexMatch.Groups[2].Value, ParentContext);
+
+            if (e.IsNull())
+            {
+                State = ExecutionState.DONE;
+            }
+            else
+            {
+                targetVolume.AppendToName(targetFile, e.ToString());
+                State = ExecutionState.DONE;
+            }
+        }
+    }
     
     [CommandAttribute(@"^COPY (.+?) (TO|FROM)( VOLUME)? (.+?)$")]
     public class CommandCopy : Command

--- a/README.md
+++ b/README.md
@@ -169,6 +169,15 @@ Example:
     PRINT 4+1.
     PRINT “4 times 8 is: “ + (4*8).
 
+### LOG
+
+Logs the selected text to a file on the archive volume. Can print strings, or the result of an expression.   Note: The archive volume must be within range of the ship or the messages are lost in space.  See antennas to increase communication range.
+Example:
+
+    LOG mylog “Hello”.
+    LOG mylog 4+1.
+    LOG mylog “4 times 8 is: “ + (4*8).
+
 ### RENAME
 
 Renames a file or volume.

--- a/Volume.cs
+++ b/Volume.cs
@@ -26,6 +26,9 @@ namespace kOS
             return null;
         }
 
+        // Used by LOG command.  For now not allowing logging to volumes other than archive (if it is in range).
+        public virtual void AppendToName(string name, string str) { return; }
+
         public virtual void DeleteByName(String name)
         {
             foreach (File p in files)
@@ -176,6 +179,25 @@ namespace kOS
             }
 
             return true;
+        }
+
+        // Appends to a file on the archive volume if the archive is within range.
+        public override void AppendToName(string name, string str)
+        {
+            try
+            {
+                using (StreamWriter outfile = new StreamWriter(ArchiveFolder + name + ".txt", true))
+                {
+                    // Evil line break for windows
+                    str +=  Application.platform == RuntimePlatform.WindowsPlayer ? "\r\n" : "\n";
+
+                    outfile.Write(str);
+                }
+            }
+            catch (Exception e)
+            {
+                return;
+            }
         }
 
         public override void DeleteByName(string name)


### PR DESCRIPTION
Otherwise the message is lost to space.

Works similarly to PRINT with the addition of a log filename argument.
  LOG mylog "Hello Eve."
Would append "Hello Eve." to the end of the mylog.txt file on the archive
volume.

When out of range, the message is silently dropped.

Note:  At this time I didn't think it was a good ideas to support logging to volumes on the ship as it would quickly eat up space and I need to think about ways to manage that and keep the user experience simple.    Also it is kind of fun to have to deal with KSP being withing range to get your telemetry data from your program.
