### PR TITLE
Support multiplication of scalar and vector

### DIFF
--- a/Expression.cs
+++ b/Expression.cs
@@ -831,6 +831,15 @@ namespace kOS
                     if (Operator == "!=") return LeftSide.Value.ToString() != RightSide.Value.ToString();
                 }
 
+                if (LeftSide.Value is float && RightSide.Value is Vector)
+                {
+                    if (Operator == "*") return (Vector)RightSide.GetValue() * (Vector)LeftSide.Float();
+                }
+                if (LeftSide.Value is Vector && RightSide.Value is float)
+                {
+                    if (Operator == "*") return (Vector)LeftSide.GetValue() * (Vector)RightSide.Float();
+                }
+
                 if (LeftSide.Value is float || RightSide.Value is float)
                 {
                     if (Operator == "+") return LeftSide.Float() + RightSide.Float();

--- a/Vector.cs
+++ b/Vector.cs
@@ -67,6 +67,7 @@ namespace kOS
         }
 
         public static Vector operator *(Vector a, Vector b) { return new Vector(a.x * b.x, a.y * b.y, a.z * b.z); }
+        public static Vector operator *(Vector a, float b) { return new Vector(a.x * b, a.y * b, a.z * b); }
         public static Vector operator +(Vector a, Vector b) { return new Vector(a.ToVector3D() + b.ToVector3D()); }
         public static Vector operator -(Vector a, Vector b) { return new Vector(a.ToVector3D() - b.ToVector3D()); }
     }


### PR DESCRIPTION
This should support the multiplication of a scalar and vector:

```
set A to V(0,1,2) * -1.
```

This will result in the vector being `(0,-1,-2)`. Implements #94.
