### PR TITLE
Swapping the order of initCpu and harddisk initialization

### DIFF
--- a/kOSProcessor.cs
+++ b/kOSProcessor.cs
@@ -65,9 +65,10 @@ namespace kOS
                 return;
             }
 
+            if (hardDisk == null) hardDisk = new Harddisk(MemSize);
+
             initCpu();
 
-            if (hardDisk == null) hardDisk = new Harddisk(MemSize);
         }
 
         public void initCpu()


### PR DESCRIPTION
I think this solves issue #108.  It is my first attempt to push a change so be careful to check what I did.

The problem is that in the initialization of the KOS CPU unit, even though  initCPU() appears to be written to expect harddisk to already be set by the time it's called, harddisk wasn't set yet.  It was set after initCPU() was called.  I think swapping the order of these two lines is the correct thing to do.
At the least, doing that made the problem in issue #108 go away when I tried it.
