### PR TITLE
Allow the velocity to be a vector

### DIFF
--- a/VesselVelocity.cs
+++ b/VesselVelocity.cs
@@ -5,33 +5,26 @@ using System.Text;
 
 namespace kOS
 {
-    public class VesselVelocity : SpecialValue
+    public class VesselVelocity : Vector
     {
-        Vector orbitVelocity;
         Vector surfaceVelocity;
         float velocityHeading;
 
-        public VesselVelocity(Vessel v)
+        public VesselVelocity(Vessel v) : base(v.obt_velocity)
         {
-            orbitVelocity = new Vector(v.obt_velocity);
             surfaceVelocity = new Vector(v.srf_velocity);
             velocityHeading = VesselUtils.GetVelocityHeading(v);
         }
 
         public override object GetSuffix(string suffixName)
         {
-            if (suffixName == "ORBIT") return orbitVelocity;
+            if (suffixName == "ORBIT") return this;
             if (suffixName == "SURFACE") return surfaceVelocity;
 
             // I created this one for debugging purposes only, at some point I'll make a function to transform vectors to headings in a more eloquent way
             if (suffixName == "SURFACEHEADING") return velocityHeading;
 
             return base.GetSuffix(suffixName);
-        }
-
-        public override string ToString()
-        {
-            return orbitVelocity.ToString();
         }
     }
 }


### PR DESCRIPTION
Hi, in #145 it was noted that velocity doesn't default to the orbital velocity vector. This patch should do the trick: `VELOCITY` is then the orbital vector but additionally stores the surface vector.

**DISCLAIMER**: As my computer is not set up for development and testing C#, I'm not sure that this code works as promised. (I really have to set up my computer for developing KSP plugins)
