### PR TITLE
Remove the comment and then check that for delimiter match

### DIFF
--- a/ContextRunProgram.cs
+++ b/ContextRunProgram.cs
@@ -31,11 +31,12 @@ namespace kOS
             foreach (String line in file)
             {
 
-                commandBuffer += stripComment(line);
+                line = stripComment(line);
 				if (!Utils.DelimterMatch (line)) 
 				{
 					throw new kOSException ("line" + lineNumber +": mismatching delimiter.");
 				}
+                commandBuffer += line
                 string cmd;
                 while (parseNext(ref commandBuffer, out cmd))
                 {


### PR DESCRIPTION
This should partially fix #152 as it removes the comment from the currently parsed line and then checked this striped line for matching delimiters. Previously, the check was done on the unmodified string which also checked in the comments.

**DISCLAIMER**: As my computer is not set up for development and testing C#, I'm not sure that this code works as promised. (I really have to set up my computer for developing KSP plugins)
