### PR TITLE
Interpreter buffer refactor

### DIFF
--- a/InterpreterBootup.cs
+++ b/InterpreterBootup.cs
@@ -16,7 +16,6 @@ namespace kOS
         public InterpreterBootup(ExecutionContext parent)
             : base(parent) 
         {
-            //ShowAnimationFrame(0);
             PrintAt("BOOTING UP...", 22, 20);
 
             State = ExecutionState.WAIT;
@@ -29,16 +28,9 @@ namespace kOS
 
         public void PrintAt(String text, int x, int y)
         {
-            var cA = text.ToCharArray();
-
-            for (int i = 0; i < text.Length; i++)
-            {
-                char c = cA[i];
-
-                if (x + i >= BufferWidth) return;
-
-                buffer[y, x + i] = c;
-            }
+            int count = Math.Min(text.Length, BufferWidth - x);
+            int offset = y * BufferWidth + x;
+            Buffer.BlockCopy(text.ToCharArray(), 0, buffer, offset * sizeof(char), count * sizeof(char));
         }
 
         public override void Update(float time)

--- a/InterpreterBootup.cs
+++ b/InterpreterBootup.cs
@@ -7,9 +7,11 @@ namespace kOS
 {
     public class InterpreterBootup : ExecutionContext
     {
+        int BufferWidth { get { return buffer.GetLength(1); } }
+        int BufferHeight { get { return buffer.GetLength(0); } }
         private float bootTime = 0;
         private float animationTime = 0;
-        private new char[,] buffer = new char[COLUMNS, ROWS];
+        private new char[,] buffer = new char[ROWS, COLUMNS];
 
         public InterpreterBootup(ExecutionContext parent)
             : base(parent) 
@@ -33,9 +35,9 @@ namespace kOS
             {
                 char c = cA[i];
 
-                if (x + i >= buffer.GetLength(0)) return;
+                if (x + i >= BufferWidth) return;
 
-                buffer[x + i, y] = c;
+                buffer[y, x + i] = c;
             }
         }
 
@@ -68,7 +70,7 @@ namespace kOS
 
                     char c = (char)(sY * 16 + sX);
 
-                    buffer[tX + x, tY + y] = c;
+                    buffer[tY + y, tX + x] = c;
                 }
             }
         }

--- a/InterpreterEdit.cs
+++ b/InterpreterEdit.cs
@@ -100,13 +100,7 @@ namespace kOS
 
         private void ClearScreen()
         {
-            for (int y = 0; y < BufferHeight; y++)
-            {
-                for (int x = 0; x < BufferWidth; x++)
-                {
-                    buffer[y, x] = (char)0;
-                }
-            }
+            Array.Clear(buffer, 0, buffer.Length);
         }
 
         public override char[,] GetBuffer()
@@ -273,21 +267,15 @@ namespace kOS
 
         public void Print(int sx, int sy, String value, int max)
         {
-            char[] chars = value.ToCharArray();
-            int i = 0;
-            for (int x = sx; (x < BufferWidth && i < chars.Count() && i < max); x++)
-            {
-                buffer[sy, x] = chars[i];
-                i++;
-            }
+            int count = Math.Min(max, Math.Min(value.Length, BufferWidth - sx));
+            int offset = sy * BufferWidth + sx;
+            Buffer.BlockCopy(value.ToCharArray(), 0, buffer, offset * sizeof(char), count * sizeof(char));
         }
 
         public void PrintBorder(int y)
         {
-            for (int x = 0; x < BufferWidth; x++)
-            {
-                buffer[y, x] = '-';
-            }
+            var border = Enumerable.Repeat('-', BufferWidth).ToArray();
+            Buffer.BlockCopy(border, 0, buffer, y * BufferWidth * sizeof(char), BufferWidth * sizeof(char));
         }
 
         private void Exit()

--- a/InterpreterEdit.cs
+++ b/InterpreterEdit.cs
@@ -7,8 +7,8 @@ namespace kOS
 {
     public class InterpreterEdit : ExecutionContext
     {
-        int BufferWidth { get { return buffer.GetLength(0); } }
-        int BufferHeight { get { return buffer.GetLength(1); } }
+        int BufferWidth { get { return buffer.GetLength(1); } }
+        int BufferHeight { get { return buffer.GetLength(0); } }
         int CursorLine = 0;
         int CursorCol = 0;
         int ProgramSize = 0;
@@ -19,7 +19,7 @@ namespace kOS
         int CursorX = 0;
         int CursorY = 0;
 
-        private new char[,] buffer = new char[COLUMNS, ROWS];
+        private new char[,] buffer = new char[ROWS, COLUMNS];
 
         String StatusAnimString = "";
         float StatusAnimProg = 0;
@@ -100,11 +100,11 @@ namespace kOS
 
         private void ClearScreen()
         {
-            for (int y = 0; y < buffer.GetLength(1); y++)
+            for (int y = 0; y < BufferHeight; y++)
             {
-                for (int x = 0; x < buffer.GetLength(0); x++)
+                for (int x = 0; x < BufferWidth; x++)
                 {
-                    buffer[x, y] = (char)0;
+                    buffer[y, x] = (char)0;
                 }
             }
         }
@@ -277,7 +277,7 @@ namespace kOS
             int i = 0;
             for (int x = sx; (x < BufferWidth && i < chars.Count() && i < max); x++)
             {
-                buffer[x, sy] = chars[i];
+                buffer[sy, x] = chars[i];
                 i++;
             }
         }
@@ -286,7 +286,7 @@ namespace kOS
         {
             for (int x = 0; x < BufferWidth; x++)
             {
-                buffer[x, y] = '-';
+                buffer[y, x] = '-';
             }
         }
 

--- a/TermWindow.cs
+++ b/TermWindow.cs
@@ -265,12 +265,12 @@ namespace kOS
                 {
                     char[,] buffer = Cpu.GetBuffer();
 
-                    for (var x = 0; x < buffer.GetLength(0); x++)
-                        for (var y = 0; y < buffer.GetLength(1); y++)
+                    for (var y = 0; y < buffer.GetLength(0); y++)
+                        for (var x = 0; x < buffer.GetLength(1); x++)
                         {
-                            char c = buffer[x, y];
+                            char c = buffer[y, x];
 
-                            if (c != 0 && c != 9 && c != 32) ShowCharacterByAscii(buffer[x, y], x, y, textColor);
+                            if (c != 0 && c != 9 && c != 32) ShowCharacterByAscii(c, x, y, textColor);
                         }
 
                     bool blinkOn = cursorBlinkTime < 0.5f;


### PR DESCRIPTION
Stores the interpreters' buffer as [y, x] instead of [x, y]. This allows the Array and Buffer library to work on the buffer directly and is much more efficient than setting individual elements.
