### PR TITLE
-Added volume:selected and volume:freespace

### DIFF
--- a/BindingsTerminalSettings.cs
+++ b/BindingsTerminalSettings.cs
@@ -11,6 +11,15 @@ namespace kOS
         public override void AddTo(BindingManager manager)
         {
             manager.AddGetter("SESSIONTIME", delegate(CPU cpu) { return cpu.SessionTime; });
+
+            manager.AddGetter("VOLUME:SELECTED", delegate(CPU cpu)
+            {
+                // if the user hasn't selected another volume, name will remain empty
+                // return 1, as the user will still be on the default volume, 1
+                if (cpu.SelectedVolume.Name == null || cpu.SelectedVolume.Name.Length == 0) { return "1"; }
+                else { return cpu.SelectedVolume.Name; }
+            });
+            manager.AddGetter("VOLUME:FREESPACE", delegate(CPU cpu) { return cpu.SelectedVolume.GetFreeSpace(); });
         }
     }
 }

--- a/kOS.csproj
+++ b/kOS.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <Reference Include="Assembly-CSharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Games\KSP220\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\KSP_win\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -43,7 +43,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\Lib\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\KSP_win\KSP_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -97,6 +97,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="VesselUtils.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Service References\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>


### PR DESCRIPTION
Added selected volume and volume free space data, in response to the request in issue #153.

volume:selected returns the name of the selected volume as a string. I added it in the comments, but if the user hasn't selected a new volume, the cpu.selectedVolume.name returns blank. I added a quick fix there because I didn't want to start messing around too deeply in the code. 

volume:freespace returns the freespace of the current volume as an int, no problems. 
