### PR TITLE
Made SpecialValue even more special. ...

### DIFF
--- a/Expression.cs
+++ b/Expression.cs
@@ -27,7 +27,11 @@ namespace kOS
 
         public object GetValue()
         {
-            return GetValueOfTerm(rootTerm);
+            Object value = GetValueOfTerm(rootTerm);
+            if (value is SpecialValue)
+                value = ((SpecialValue)value).Value;
+
+            return value;
         }
 
         public object GetValueOfTerm(Term term)
@@ -247,6 +251,14 @@ namespace kOS
                 {
                     output = ((SpecialValue)baseTermValue).GetSuffix(suffixTerm.Text.ToUpper());
                     if (output != null) return output;
+
+                    // Check if the SpecialValues projection is another SpesialValue that possible supports the suffux.
+                    if (baseTermValue != ((SpecialValue)baseTermValue).Value && ((SpecialValue)baseTermValue).Value is SpecialValue)
+                    {
+                        baseTermValue = ((SpecialValue)baseTermValue).Value;
+                        output = ((SpecialValue)baseTermValue).GetSuffix(suffixTerm.Text.ToUpper());
+                        if (output != null) return output;
+                    }
 
                     throw new kOSException("Suffix '" + suffixTerm.Text + "' not found on object", executionContext);
                 }

--- a/SpecialValue.cs
+++ b/SpecialValue.cs
@@ -7,6 +7,11 @@ namespace kOS
 {
     public class SpecialValue
     {
+        public virtual Object Value
+        {
+            get { return this; }
+        }
+
         public virtual bool SetSuffix(String suffixName, object value)
         {
             return false;


### PR DESCRIPTION
Override of "Value" property enables projection of different datatype when no suffix is used. An example would be:

SENSOR:ACC:ACTIVE -> Here the SENSOR:ACC returns a sensor object that can handle suffixes.
SENSOR:ACC without suffix would return the object of the Value property. This example returns a vector that can be used for vector operations.
SENSOR:ACC:MAG -> since the sensor object does not support the MAG suffix, the expression engine tries to use the object returned from the Value property before it fails. In this example the Value property returns a vector and thus the term is valid and will return the magnitude of the vector representing the sensor value.

The default implementation is to return the SpecialValue itself ("return this;"). This ensures no existing functionality is affected.
