### PR TITLE
Add ability to lock WHEELSTEERING to bare heading.

### DIFF
--- a/BindingsFlightControl.cs
+++ b/BindingsFlightControl.cs
@@ -136,6 +136,10 @@ namespace kOS
                         {
                             bearing = ((GeoCoordinates)Value).GetBearing(vessel);
                         }
+                        else if (Value is double)
+                        {
+                            bearing = (float)(Math.Round((double)Value) - Mathf.Round(FlightGlobals.ship_heading));
+                        }
 
                         if (vessel.horizontalSrfSpeed > 0.1f)
                         { 


### PR DESCRIPTION
```
lock wheelsteering to 320.
```

Partially rectifies issues in #223. Need a good solution for the unnecessary loop it does when going from 0 to 320 for example. Readme changes will be in that monster #203. Going to rework the Flight Control section. Lunch is over.
