### PR TITLE
Allow WARP to be used in comparisons.

### DIFF
--- a/BindingsUniverse.cs
+++ b/BindingsUniverse.cs
@@ -10,7 +10,7 @@ namespace kOS
     {
         public override void AddTo(BindingManager manager)
         {
-            manager.AddGetter("WARP", delegate(CPU cpu) { return TimeWarp.fetch.current_rate_index; });
+            manager.AddGetter("WARP", delegate(CPU cpu) { return (double)TimeWarp.fetch.current_rate_index; });
             manager.AddSetter("WARP", delegate(CPU cpu, object val)
             {
                 int newRate;


### PR DESCRIPTION
TimeWarp.fetch.current_rate_index returns int.

```
warp != 0
```
