### PR TITLE
Make ENCOUNTER return null OrbitInfo with default values.

### DIFF
--- a/Orbit.cs
+++ b/Orbit.cs
@@ -5,32 +5,35 @@ using System.Text;
 
 namespace kOS
 {
-    public class OrbitInfo : SpecialValue
+  public class OrbitInfo : SpecialValue
+  {
+    Orbit orbitRef;
+
+    public OrbitInfo(Orbit init)
     {
-        Orbit orbitRef;
-
-        public OrbitInfo(Orbit init)
-        {
-            this.orbitRef = init;
-        }
-
-        public override object GetSuffix(string suffixName)
-        {
-            if (suffixName == "APOAPSIS") return orbitRef.ApA;
-            else if (suffixName == "PERIAPSIS") return orbitRef.PeA;
-            else if (suffixName == "BODY") return orbitRef.referenceBody.name;
-
-            return base.GetSuffix(suffixName);
-        }
-
-        public override string ToString()
-        {
-            if (orbitRef != null)
-            {
-                return orbitRef.referenceBody.name;
-            }
-
-            return "";
-        }
+      this.orbitRef = init;
     }
+
+    public override object GetSuffix(string suffixName)
+    {
+      if (suffixName == "APOAPSIS")
+        return orbitRef != null ? orbitRef.ApA : 0;
+      else if (suffixName == "PERIAPSIS")
+        return orbitRef != null ? orbitRef.PeA : 0;
+      else if (suffixName == "BODY")
+        return orbitRef != null ? orbitRef.referenceBody.name : "None";
+
+      return base.GetSuffix(suffixName);
+    }
+
+    public override string ToString()
+    {
+      if (orbitRef != null)
+      {
+        return orbitRef.referenceBody.name;
+      }
+
+      return "None";
+    }
+  }
 }

--- a/VesselUtils.cs
+++ b/VesselUtils.cs
@@ -262,7 +262,7 @@ namespace kOS
         }
       }
 
-      return "None";
+      return new OrbitInfo(null);
     }
 
     public static void LandingLegsCtrl(Vessel vessel, bool state)


### PR DESCRIPTION
Somewhat addresses #243 but the real issue that needs to be fixed is eluding me for now.

```
if encounter == "Mun" { awesome things }.
```

In the above example i believe kOS doesn't think value 2 is a string. A simple workaround is to declare a variable and compare that.

```
set trgt to "Mun".
if encounter == trgt { magic things }.
```

monodevel and it's indenting RAGE
