### PR TITLE
Return 0 if vessel is on escape trajectory. Since KSP recalcs the orbit ...

### DIFF
--- a/BindingsFlightStats.cs
+++ b/BindingsFlightStats.cs
@@ -14,10 +14,10 @@ namespace kOS
         public override void AddTo(BindingManager manager)
         {
             manager.AddGetter("ALT:RADAR",      delegate(CPU cpu) { return cpu.Vessel.heightFromTerrain > 0 ? Mathf.Min(cpu.Vessel.heightFromTerrain, (float)cpu.Vessel.altitude) : (float)cpu.Vessel.altitude; });
-            manager.AddGetter("ALT:APOAPSIS",   delegate(CPU cpu) { return cpu.Vessel.orbit.ApA; });
-            manager.AddGetter("ALT:PERIAPSIS",  delegate(CPU cpu) { return cpu.Vessel.orbit.PeA; });
-            manager.AddGetter("ETA:APOAPSIS",   delegate(CPU cpu) { return cpu.Vessel.orbit.timeToAp; });
-            manager.AddGetter("ETA:PERIAPSIS",  delegate(CPU cpu) { return cpu.Vessel.orbit.timeToPe; });
+            manager.AddGetter("ALT:APOAPSIS",   delegate(CPU cpu) { if (cpu.Vessel.situation.ToString() == "ESCAPING") { return 0;} else return cpu.Vessel.orbit.ApA; });
+            manager.AddGetter("ALT:PERIAPSIS",  delegate(CPU cpu) { if (cpu.Vessel.situation.ToString() == "ESCAPING") { return 0;} else return cpu.Vessel.orbit.PeA; });
+            manager.AddGetter("ETA:APOAPSIS",   delegate(CPU cpu) { if (cpu.Vessel.situation.ToString() == "ESCAPING") { return 0;} else return cpu.Vessel.orbit.timeToAp; });
+            manager.AddGetter("ETA:PERIAPSIS",  delegate(CPU cpu) { if (cpu.Vessel.situation.ToString() == "ESCAPING") { return 0;} else return cpu.Vessel.orbit.timeToPe; });
 
             manager.AddGetter("MISSIONTIME",    delegate(CPU cpu) { return cpu.Vessel.missionTime; });
             manager.AddGetter("TIME",           delegate(CPU cpu) { return new kOS.TimeSpan(Planetarium.GetUniversalTime()); });

--- a/VesselTarget.cs
+++ b/VesselTarget.cs
@@ -99,8 +99,8 @@ namespace kOS
             if (suffixName == "AIRSPEED") return (target.orbit.GetVel() - FlightGlobals.currentMainBody.getRFrmVel(target.GetWorldPos3D())).magnitude; //the velocity of the vessel relative to the air);
             if (suffixName == "VESSELNAME") return  target.vesselName;
             if (suffixName == "ALTITUDE") return target.altitude;
-            if (suffixName == "APOAPSIS") return  target.orbit.ApA;
-            if (suffixName == "PERIAPSIS") return  target.orbit.PeA; 
+            if (suffixName == "APOAPSIS") if (target.situation.ToString() == "ESCAPING") { return 0;} else return  target.orbit.ApA;
+            if (suffixName == "PERIAPSIS") if (target.situation.ToString() == "ESCAPING") { return 0;} else return  target.orbit.PeA;
             if (suffixName == "SENSOR") return new VesselSensors(target);
             if (suffixName == "TERMVELOCITY") return VesselUtils.GetTerminalVelocity(target);
 


### PR DESCRIPTION
...constantly it returns random results during escape. Somewhat address #248. Probably need to work about a policy on return values. I have currently been doing "None" for strings and 0 for numbers. I'll continue down that route until told otherwise.
