### PR TITLE
RFC: new saving/loading of save file variables.

### DIFF
--- a/CPU.cs
+++ b/CPU.cs
@@ -360,7 +360,6 @@ namespace kOS
 
             foreach (var kvp in Variables)
             {
-              Debug.Log("NAME: " + kvp.Key.ToString());
               if (!(kvp.Value is BoundVariable))
               {
                 if (kvp.Value.Value is Double)


### PR DESCRIPTION
This splits up variables in five nodes: numbers, strings, bools, kostypes and variables. The latter is for when it's not the first four. That is for debugging and can be removed. It casts the strings to string,numbers to double and bools to bool, putting kostypes through Expression.

This fixes #220 as far as i can tell at the cost of breaking old saves. Anyone know how to convert in a reasonable way? I'll link a compiled dll upon request.
