### PR TITLE
added some useful flight stats

### DIFF
--- a/BindingsFlightControl.cs
+++ b/BindingsFlightControl.cs
@@ -80,8 +80,8 @@ namespace kOS
                 locked = false;
                 Value = 0;
                 
-                manager.AddGetter(name, delegate(CPU c) { return Value; });
-                manager.AddSetter(name, delegate(CPU c, object val)  { });
+                manager.AddGetter(name, c => Value);
+                manager.AddSetter(name, delegate{});
 
                 this.propertyName = propertyName;
             }
@@ -173,45 +173,45 @@ namespace kOS
     {
         public override void AddTo(BindingManager manager)
         {
-            manager.AddSetter("SAS", delegate(CPU cpu, object val) { cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.SAS, (bool)val); });
-            manager.AddSetter("GEAR", delegate(CPU cpu, object val) { cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Gear, (bool)val); });
-            manager.AddSetter("LEGS", delegate(CPU cpu, object val) {  VesselUtils.LandingLegsCtrl(cpu.Vessel, (bool)val); });
-            manager.AddSetter("CHUTES", delegate(CPU cpu, object val) {  VesselUtils.DeployParachutes(cpu.Vessel, (bool)val); });
-            manager.AddSetter("LIGHTS", delegate(CPU cpu, object val) { cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Light, (bool)val); });
-            manager.AddSetter("PANELS", delegate(CPU cpu, object val) {  VesselUtils.SolarPanelCtrl(cpu.Vessel, (bool)val); });
-            manager.AddSetter("BRAKES", delegate(CPU cpu, object val) { cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Brakes, (bool)val); });
-            manager.AddSetter("RCS", delegate(CPU cpu, object val) { cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.RCS, (bool)val); });
-            manager.AddSetter("ABORT", delegate(CPU cpu, object val) { cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Abort, (bool)val); });
-            manager.AddSetter("AG1", delegate(CPU cpu, object val) { cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom01, (bool)val); });
-            manager.AddSetter("AG2", delegate(CPU cpu, object val) { cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom02, (bool)val); });
-            manager.AddSetter("AG3", delegate(CPU cpu, object val) { cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom03, (bool)val); });
-            manager.AddSetter("AG4", delegate(CPU cpu, object val) { cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom04, (bool)val); });
-            manager.AddSetter("AG5", delegate(CPU cpu, object val) { cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom05, (bool)val); });
-            manager.AddSetter("AG6", delegate(CPU cpu, object val) { cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom06, (bool)val); });
-            manager.AddSetter("AG7", delegate(CPU cpu, object val) { cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom07, (bool)val); });
-            manager.AddSetter("AG8", delegate(CPU cpu, object val) { cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom08, (bool)val); });
-            manager.AddSetter("AG9", delegate(CPU cpu, object val) { cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom09, (bool)val); });
-            manager.AddSetter("AG10", delegate(CPU cpu, object val) { cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom10, (bool)val); });
+            manager.AddSetter("SAS", (cpu, val) => cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.SAS, (bool) val));
+            manager.AddSetter("GEAR", (cpu, val) => cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Gear, (bool) val));
+            manager.AddSetter("LEGS", (cpu, val) => VesselUtils.LandingLegsCtrl(cpu.Vessel, (bool) val));
+            manager.AddSetter("CHUTES", (cpu, val) => VesselUtils.DeployParachutes(cpu.Vessel, (bool) val));
+            manager.AddSetter("LIGHTS", (cpu, val) => cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Light, (bool) val));
+            manager.AddSetter("PANELS", (cpu, val) => VesselUtils.SolarPanelCtrl(cpu.Vessel, (bool) val));
+            manager.AddSetter("BRAKES", (cpu, val) => cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Brakes, (bool) val));
+            manager.AddSetter("RCS", (cpu, val) => cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.RCS, (bool) val));
+            manager.AddSetter("ABORT", (cpu, val) => cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Abort, (bool) val));
+            manager.AddSetter("AG1", (cpu, val) => cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom01, (bool) val));
+            manager.AddSetter("AG2", (cpu, val) => cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom02, (bool) val));
+            manager.AddSetter("AG3", (cpu, val) => cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom03, (bool) val));
+            manager.AddSetter("AG4", (cpu, val) => cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom04, (bool) val));
+            manager.AddSetter("AG5", (cpu, val) => cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom05, (bool) val));
+            manager.AddSetter("AG6", (cpu, val) => cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom06, (bool) val));
+            manager.AddSetter("AG7", (cpu, val) => cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom07, (bool) val));
+            manager.AddSetter("AG8", (cpu, val) => cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom08, (bool) val));
+            manager.AddSetter("AG9", (cpu, val) => cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom09, (bool) val));
+            manager.AddSetter("AG10", (cpu, val) => cpu.Vessel.ActionGroups.SetGroup(KSPActionGroup.Custom10, (bool) val));
 
-            manager.AddGetter("SAS", delegate(CPU cpu) { return cpu.Vessel.ActionGroups[KSPActionGroup.SAS]; });
-            manager.AddGetter("GEAR", delegate(CPU cpu) { return cpu.Vessel.ActionGroups[KSPActionGroup.Gear]; });
-            manager.AddGetter("LEGS", delegate(CPU cpu) { return VesselUtils.GetLandingLegStatus(cpu.Vessel); });
-            manager.AddGetter("CHUTES", delegate(CPU cpu) { return VesselUtils.GetChuteStatus(cpu.Vessel); });
-            manager.AddGetter("LIGHTS", delegate(CPU cpu) { return cpu.Vessel.ActionGroups[KSPActionGroup.Light]; });
-            manager.AddGetter("PANELS", delegate(CPU cpu) { return VesselUtils.GetSolarPanelStatus(cpu.Vessel); });
-            manager.AddGetter("BRAKES", delegate(CPU cpu) { return cpu.Vessel.ActionGroups[KSPActionGroup.Brakes]; });
-            manager.AddGetter("RCS", delegate(CPU cpu) { return cpu.Vessel.ActionGroups[KSPActionGroup.RCS]; });
-            manager.AddGetter("ABORT", delegate(CPU cpu) { return cpu.Vessel.ActionGroups[KSPActionGroup.Abort]; });
-            manager.AddGetter("AG1", delegate(CPU cpu) { return cpu.Vessel.ActionGroups[KSPActionGroup.Custom01]; });
-            manager.AddGetter("AG2", delegate(CPU cpu) { return cpu.Vessel.ActionGroups[KSPActionGroup.Custom02]; });
-            manager.AddGetter("AG3", delegate(CPU cpu) { return cpu.Vessel.ActionGroups[KSPActionGroup.Custom03]; });
-            manager.AddGetter("AG4", delegate(CPU cpu) { return cpu.Vessel.ActionGroups[KSPActionGroup.Custom04]; });
-            manager.AddGetter("AG5", delegate(CPU cpu) { return cpu.Vessel.ActionGroups[KSPActionGroup.Custom05]; });
-            manager.AddGetter("AG6", delegate(CPU cpu) { return cpu.Vessel.ActionGroups[KSPActionGroup.Custom06]; });
-            manager.AddGetter("AG7", delegate(CPU cpu) { return cpu.Vessel.ActionGroups[KSPActionGroup.Custom07]; });
-            manager.AddGetter("AG8", delegate(CPU cpu) { return cpu.Vessel.ActionGroups[KSPActionGroup.Custom08]; });
-            manager.AddGetter("AG9", delegate(CPU cpu) { return cpu.Vessel.ActionGroups[KSPActionGroup.Custom09]; });
-            manager.AddGetter("AG10", delegate(CPU cpu) { return cpu.Vessel.ActionGroups[KSPActionGroup.Custom10]; });
+            manager.AddGetter("SAS", cpu => cpu.Vessel.ActionGroups[KSPActionGroup.SAS]);
+            manager.AddGetter("GEAR", cpu => cpu.Vessel.ActionGroups[KSPActionGroup.Gear]);
+            manager.AddGetter("LEGS", cpu => VesselUtils.GetLandingLegStatus(cpu.Vessel));
+            manager.AddGetter("CHUTES", cpu => VesselUtils.GetChuteStatus(cpu.Vessel));
+            manager.AddGetter("LIGHTS", cpu => cpu.Vessel.ActionGroups[KSPActionGroup.Light]);
+            manager.AddGetter("PANELS", cpu => VesselUtils.GetSolarPanelStatus(cpu.Vessel));
+            manager.AddGetter("BRAKES", cpu => cpu.Vessel.ActionGroups[KSPActionGroup.Brakes]);
+            manager.AddGetter("RCS", cpu => cpu.Vessel.ActionGroups[KSPActionGroup.RCS]);
+            manager.AddGetter("ABORT", cpu => cpu.Vessel.ActionGroups[KSPActionGroup.Abort]);
+            manager.AddGetter("AG1", cpu => cpu.Vessel.ActionGroups[KSPActionGroup.Custom01]);
+            manager.AddGetter("AG2", cpu => cpu.Vessel.ActionGroups[KSPActionGroup.Custom02]);
+            manager.AddGetter("AG3", cpu => cpu.Vessel.ActionGroups[KSPActionGroup.Custom03]);
+            manager.AddGetter("AG4", cpu => cpu.Vessel.ActionGroups[KSPActionGroup.Custom04]);
+            manager.AddGetter("AG5", cpu => cpu.Vessel.ActionGroups[KSPActionGroup.Custom05]);
+            manager.AddGetter("AG6", cpu => cpu.Vessel.ActionGroups[KSPActionGroup.Custom06]);
+            manager.AddGetter("AG7", cpu => cpu.Vessel.ActionGroups[KSPActionGroup.Custom07]);
+            manager.AddGetter("AG8", cpu => cpu.Vessel.ActionGroups[KSPActionGroup.Custom08]);
+            manager.AddGetter("AG9", cpu => cpu.Vessel.ActionGroups[KSPActionGroup.Custom09]);
+            manager.AddGetter("AG10", cpu => cpu.Vessel.ActionGroups[KSPActionGroup.Custom10]);
         }
     }
 

--- a/BindingsFlightStats.cs
+++ b/BindingsFlightStats.cs
@@ -13,11 +13,15 @@ namespace kOS
     {
         public override void AddTo(BindingManager manager)
         {
-            manager.AddGetter("ALT:RADAR",      delegate(CPU cpu) { return cpu.Vessel.heightFromTerrain > 0 ? Mathf.Min(cpu.Vessel.heightFromTerrain, (float)cpu.Vessel.altitude) : (float)cpu.Vessel.altitude; });
-            manager.AddGetter("ALT:APOAPSIS",   delegate(CPU cpu) { return cpu.Vessel.orbit.ApA; });
-            manager.AddGetter("ALT:PERIAPSIS",  delegate(CPU cpu) { return cpu.Vessel.orbit.PeA; });
-            manager.AddGetter("ETA:APOAPSIS",   delegate(CPU cpu) { return cpu.Vessel.orbit.timeToAp; });
-            manager.AddGetter("ETA:PERIAPSIS",  delegate(CPU cpu) { return cpu.Vessel.orbit.timeToPe; });
+            manager.AddGetter("ALT:RADAR",
+                              cpu =>
+                              cpu.Vessel.heightFromTerrain > 0
+                                  ? Mathf.Min(cpu.Vessel.heightFromTerrain, (float) cpu.Vessel.altitude)
+                                  : (float) cpu.Vessel.altitude);
+            manager.AddGetter("ALT:APOAPSIS", cpu => cpu.Vessel.orbit.ApA);
+            manager.AddGetter("ALT:PERIAPSIS", cpu => cpu.Vessel.orbit.PeA);
+            manager.AddGetter("ETA:APOAPSIS", cpu => cpu.Vessel.orbit.timeToAp);
+            manager.AddGetter("ETA:PERIAPSIS", cpu => cpu.Vessel.orbit.timeToPe);
             manager.AddGetter("ETA:TRANSITION", cpu => cpu.Vessel.orbit.EndUT);
             manager.AddGetter("OBT:PERIOD", cpu => cpu.Vessel.orbit.period);
             manager.AddGetter("OBT:INCLINATION", cpu => cpu.Vessel.orbit.inclination);
@@ -26,17 +30,17 @@ namespace kOS
             manager.AddGetter("OBT:SEMIMINORAXIS", cpu => cpu.Vessel.orbit.semiMinorAxis);
             manager.AddGetter("OBT:TRANSITION", cpu => cpu.Vessel.orbit.patchEndTransition);
 
-            manager.AddGetter("MISSIONTIME",    delegate(CPU cpu) { return cpu.Vessel.missionTime; });
-            manager.AddGetter("TIME",           delegate(CPU cpu) { return new kOS.TimeSpan(Planetarium.GetUniversalTime()); });
+            manager.AddGetter("MISSIONTIME", cpu => cpu.Vessel.missionTime);
+            manager.AddGetter("TIME", cpu => new TimeSpan(Planetarium.GetUniversalTime()));
 
-            manager.AddGetter("STATUS",         delegate(CPU cpu) { return cpu.Vessel.situation.ToString().Replace("_", " "); });
-            manager.AddGetter("COMMRANGE",      delegate(CPU cpu) { return VesselUtils.GetCommRange(cpu.Vessel); });
-            manager.AddGetter("INCOMMRANGE",    delegate(CPU cpu) { return Convert.ToDouble(CheckCommRange(cpu.Vessel)); });
+            manager.AddGetter("STATUS", cpu => cpu.Vessel.situation.ToString().Replace("_", " "));
+            manager.AddGetter("COMMRANGE", cpu => VesselUtils.GetCommRange(cpu.Vessel));
+            manager.AddGetter("INCOMMRANGE", cpu => Convert.ToDouble(CheckCommRange(cpu.Vessel)));
 
-            manager.AddGetter("AV", delegate(CPU cpu) { return cpu.Vessel.transform.InverseTransformDirection(cpu.Vessel.rigidbody.angularVelocity); });
-            manager.AddGetter("STAGE", delegate(CPU cpu) { return new StageValues(cpu.Vessel); });
+            manager.AddGetter("AV", cpu => cpu.Vessel.transform.InverseTransformDirection(cpu.Vessel.rigidbody.angularVelocity));
+            manager.AddGetter("STAGE", cpu => new StageValues(cpu.Vessel));
 
-            manager.AddGetter("ENCOUNTER",      delegate(CPU cpu) { return VesselUtils.TryGetEncounter(cpu.Vessel); });
+            manager.AddGetter("ENCOUNTER", cpu => VesselUtils.TryGetEncounter(cpu.Vessel));
 
             manager.AddGetter("NEXTNODE",       delegate(CPU cpu)
             {
@@ -47,12 +51,12 @@ namespace kOS
             });
 
             // Things like altitude, mass, maxthrust are now handled the same for other ships as the current ship
-            manager.AddGetter("SHIP", delegate(CPU cpu) { return new VesselTarget(cpu.Vessel, cpu); });
+            manager.AddGetter("SHIP", cpu => new VesselTarget(cpu.Vessel, cpu));
 
             // These are now considered shortcuts to SHIP:suffix
             foreach (String scName in VesselTarget.ShortCuttableShipSuffixes)
             {
-                manager.AddGetter(scName, delegate(CPU cpu) { return new VesselTarget(cpu.Vessel, cpu).GetSuffix(scName); });
+                manager.AddGetter(scName, cpu => new VesselTarget(cpu.Vessel, cpu).GetSuffix(scName));
             }
 
             manager.AddSetter("VESSELNAME", delegate(CPU cpu, object value) { cpu.Vessel.vesselName = value.ToString(); });

--- a/BindingsTerminalSettings.cs
+++ b/BindingsTerminalSettings.cs
@@ -10,8 +10,8 @@ namespace kOS
     {
         public override void AddTo(BindingManager manager)
         {
-            manager.AddGetter("SESSIONTIME", delegate(CPU cpu) { return cpu.SessionTime; });
-            manager.AddGetter("VERSION", delegate(CPU cpu) { return Core.VersionInfo; });
+            manager.AddGetter("SESSIONTIME", cpu => cpu.SessionTime);
+            manager.AddGetter("VERSION", cpu => Core.VersionInfo);
         }
     }
 }

--- a/BindingsTest.cs
+++ b/BindingsTest.cs
@@ -12,15 +12,7 @@ namespace kOS
     {
         public override void AddTo(BindingManager manager)
         {
-            manager.AddGetter("TEST:RADAR", delegate(CPU cpu)
-            {
-                return new TimeSpan(cpu.SessionTime);
-            }); 
-        }
-
-        public override void Update(float time)
-        {
-            base.Update(time);
+            manager.AddGetter("TEST:RADAR", cpu => new TimeSpan(cpu.SessionTime)); 
         }
     }
 }

--- a/BindingsUniverse.cs
+++ b/BindingsUniverse.cs
@@ -10,7 +10,7 @@ namespace kOS
     {
         public override void AddTo(BindingManager manager)
         {
-            manager.AddGetter("WARP", delegate(CPU cpu) { return TimeWarp.fetch.current_rate_index; });
+            manager.AddGetter("WARP", cpu => TimeWarp.fetch.current_rate_index);
             manager.AddSetter("WARP", delegate(CPU cpu, object val)
             {
                 int newRate;
@@ -22,7 +22,7 @@ namespace kOS
 
             foreach (CelestialBody body in FlightGlobals.fetch.bodies)
             {
-                manager.AddGetter(body.name, delegate(CPU cpu) { return new BodyTarget(body, cpu); });
+                manager.AddGetter(body.name, cpu => new BodyTarget(body, cpu));
             }
         }
     }


### PR DESCRIPTION
Many of the stats we already have access to (ie Ap, Pe) are calculated from others we didn't have (ie SMA and ECC). I added them.

Transition is interesting because it pulls the end state of the current orbit out of the simulation and as such is pretty accurate. some of the possible states are:
- FINAL //your orbit continues till the end of the simulation 
- ENCOUNTER //your orbit encounters a body orbiting your current reference body
- ESCAPE //your orbit will escape the current reference body
- MANEUVER // your orbit encounters a maneuver node

Because the simulation continues for more than one orbit, I added the time to the transition in UT, this along with OBT:PEROID and our existing time tools should let you figure out how many orbits in the future the transition will take place in. 
